### PR TITLE
Fixed task switching

### DIFF
--- a/src/emdbg/debug/px4/base.py
+++ b/src/emdbg/debug/px4/base.py
@@ -62,7 +62,8 @@ class Base:
             if name in ["sp", "r13"]:
                 name = "msp"
             if name == "msp":
-                self.write_register("r13", value)
+                # NuttX stores the SP incorrectly (is off by 4 bytes)
+                self.write_register("r13", value + 4)
             # Remove double FP registers
             if name.startswith("d"): continue
             self.write_register(name, value)


### PR DESCRIPTION
Debugging NuttX reveals that it stores an incorrect SP at regs[0] during context switching.

#### Right before the context switch via SVC call:

`0x08014410 in sys_call2 (nbr=2, parm2=537382140, parm1=537028520) at /home/alex/PX4-Autopilot/platforms/nuttx/NuttX/nuttx/arch/arm/include/syscall.h:186
186       __asm__ __volatile__
=> 0x08014410 <arm_switchcontext+10>:   00 df   svc     0`

_sp_ is as follows:
`sp             0x20036d4c          0x20036d4c`

#### In the exception entry (due to SVC)
After the SVC happens, NuttX calculates the previous sp (before exc) and stores it to r2
`157             add             r2, #HW_XCPT_SIZE                       /* R2=MSP/PSP before the interrupt was taken */
=> 0x0800821a <exception_common+17>:    02 f1 68 02     add.w   r2, r2, #104    ; 0x68`

_r2_ is as follows:
`r2             0x20036d48          537095496`

#### Workaround
The workaround below solves the problem by adding the offset to the sp stored by NuttX. Afterwards the bt works again. A complete solution is to discuss the topic with the NuttX guys.