### PR TITLE
ci: update deprecated artifact@v3 references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: ext/orbetto
       - run: meson install -C ./build --destdir ./install
         working-directory: ext/orbetto
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: orbetto-linux
           path: ext/orbetto/build/install/**/*
@@ -35,7 +35,7 @@ jobs:
         working-directory: ext/orbetto
       - run: meson install -C ./build --destdir ./install
         working-directory: ext/orbetto
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: orbetto-osx
           path: ext/orbetto/build/install/**/*


### PR DESCRIPTION
Replaces the deprecated artifact v3 actions with v4, to prevent brownouts and future problems. See Github blog post announcing this here: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.