### PR TITLE
Configurable TER value, for automatic tracing

### DIFF
--- a/ext/orbetto/README.md
+++ b/ext/orbetto/README.md
@@ -97,9 +97,11 @@ python3 -m emdbg.bench.fmu --target px4_fmu-v5x --stlink
 Reset your target and start the capture:
 
 ```
-(gdb) px4_trace_swo_stm32f7
+(gdb) px4_trace_swo_stm32f7 <TER_REG>
 (gdb) continue
 ```
+
+Values for `<TER_REG>` are as described in [TER_REG](#ter_reg).
 
 
 ### FMUv6x
@@ -114,9 +116,31 @@ python3 -m emdbg.bench.fmu --target px4_fmu-v6x --jlink
 Reset your target and start the capture:
 
 ```
-(gdb) px4_trace_swo_stm32h7
+(gdb) px4_trace_swo_stm32h7 <TER_REG>
 (gdb) continue
 ```
+
+Values for `<TER_REG>` are as described in [TER_REG](#ter_reg).
+
+
+### TER_REG
+
+The `<TER_REG>` parameter defines which stimulus ports are enabled for
+ITM and therefore which information will be included in the trace.
+The stimulus port numbers are defined in the enum contained in
+[itm.h](https://github.com/Auterion/embedded-debug-tools/blob/main/src/emdbg/patch/data/itm.h).
+Enabling stimulus port `i` requires setting bit `i` of the `TER_REG` parameter.
+
+Useful values are:
+- Task information: `0x0000000F`.
+- Workqueue scheduling: `0x00000010`.
+- Semaphore profiling: `0x000000E0`.
+- Heap profiling: `0x00000F00`.
+- DMA profiling: `0x00007000`.
+- All optional user channels: `0xFFFF0000`.
+
+As described above, they can be combined with a `bitwise or` to get combinations. For example:
+- Task information + Workqueue scheduling: `0x0000001F`.
 
 
 ### Finish

--- a/ext/orbetto/src/TRACE.md
+++ b/ext/orbetto/src/TRACE.md
@@ -36,9 +36,11 @@ python3 -m emdbg.bench.fmu --target px4_fmu-v5x --orbtrace
 Reset the target and start the capture:
 
 ```
-(gdb) px4_etm_trace_tpiu_swo_stm32f7
+(gdb) px4_etm_trace_tpiu_swo_stm32f7 <TER_REG>
 (gdb) Continue
 ```
+
+Values for `<TER_REG>` are as described in: [TER_REG](https://github.com/Auterion/embedded-debug-tools/blob/main/ext/orbetto/README.md#ter_reg).
 
 
 ### FMUv6x
@@ -53,9 +55,11 @@ python3 -m emdbg.bench.fmu --target px4_fmu-v6x --orbtrace
 Reset the target and start the capture. You might need to power cycle the target:
 
 ```
-(gdb) px4_etm_trace_tpiu_swo_stm32h7
+(gdb) px4_etm_trace_tpiu_swo_stm32h7 <TER_REG>
 (gdb) Continue
 ```
+
+Values for `<TER_REG>` are as described in: [TER_REG](https://github.com/Auterion/embedded-debug-tools/blob/main/ext/orbetto/README.md#ter_reg).
 
 
 ### Visualization

--- a/src/emdbg/debug/data/cortex_m.gdb
+++ b/src/emdbg/debug/data/cortex_m.gdb
@@ -114,21 +114,7 @@ define px4_configure_orbuculum
     ITMSYNCEna 1
 
     # Enable ITM ports
-    # We always need the task information
-    set $TER = 0x0000000F
-    # Enable workqueue scheduling
-    set $TER |= 0x00000010
-
-    # Enable semaphore profiling
-    # set $TER |= 0x000000E0
-    # Enable heap profiling
-    # set $TER |= 0x00000F00
-    # Enable DMA profiling
-    # set $TER |= 0x00007000
-
-    # Enable all optional user channels
-    set $TER |= 0xFFFF0000
-
+    set $TER = $arg0
     # Write the TER to the device
     ITMTER 0 $TER
     # Enable the ITM
@@ -201,7 +187,7 @@ define px4_etm_trace_tpiu_swo_stm32f7
 
     enableSTM32TRACE 4 3 1
 
-    px4_configure_orbuculum
+    px4_configure_orbuculum $arg0
 
     startETM
 
@@ -220,7 +206,7 @@ define px4_trace_tpiu_swo_stm32f7
 
     enableSTM32TRACE 4 3 1
 
-    px4_configure_orbuculum
+    px4_configure_orbuculum $arg0
 
     # -o trace.swo dumps the RAW data, not the demuxed data!!!
     shell killall orbuculum
@@ -234,7 +220,7 @@ define px4_etm_trace_tpiu_swo_stm32h7
 
     px4_enable_trace_stm32h7 4
 
-    px4_configure_orbuculum
+    px4_configure_orbuculum $arg0
 
     startETM
 
@@ -252,7 +238,7 @@ define px4_trace_tpiu_swo_stm32h7
 
     px4_enable_trace_stm32h7 4
 
-    px4_configure_orbuculum
+    px4_configure_orbuculum $arg0
 
     # -o trace.swo dumps the RAW data, not the demuxed data!!!
     shell killall orbuculum

--- a/src/emdbg/debug/data/jlink.gdb
+++ b/src/emdbg/debug/data/jlink.gdb
@@ -15,7 +15,7 @@ define px4_trace_swo_stm32f7
     tbreak nx_start
     continue
     monitor SWO EnableTarget 216000000 27000000 1 0
-    px4_configure_orbuculum
+    px4_configure_orbuculum $arg0
     shell nc localhost 2332 > trace.swo &
 end
 
@@ -24,6 +24,6 @@ define px4_trace_swo_stm32h7
     tbreak nx_start
     continue
     monitor SWO EnableTarget 120000000 30000000 1 0
-    px4_configure_orbuculum
+    px4_configure_orbuculum $arg0
     shell nc localhost 2332 > trace.swo &
 end

--- a/src/emdbg/debug/data/openocd.gdb
+++ b/src/emdbg/debug/data/openocd.gdb
@@ -13,7 +13,7 @@ define px4_trace_swo_stm32f7
     monitor tpiu init
     monitor itm ports off
 
-    px4_configure_orbuculum
+    px4_configure_orbuculum $arg0
 
     enableSTM32SWO 7
 end
@@ -26,7 +26,7 @@ define px4_trace_swo_stm32h7
 
     px4_enable_swo_stm32h7 60000000
 
-    px4_configure_orbuculum
+    px4_configure_orbuculum $arg0
 
     shell orbuculum -O "-Tu -a 60000000" -o trace.swo &
 end


### PR DESCRIPTION
When doing automated tracing the tool performing the trace might not require the current configured default TER values.
Currently the only way to change the TER value is to adapt emdbg source code.
This change allows passing the required TER value.